### PR TITLE
Remove config.name key from rollup.config.js

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -32,6 +32,5 @@ export default defineConfig({
     },
     format: 'iife',
     exports: 'default',
-    name: "ControllerTools",
   },
 });


### PR DESCRIPTION
Closes: https://github.com/jfernandez/ControllerTools/issues/43